### PR TITLE
feat: updated depedencies and CI

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,28 +1,12 @@
-name: CI
+name: Iconica Standard Component CI Workflow
+# Workflow Caller version: 1.0.0
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
   workflow_dispatch:
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/wrapper
-            /opt/hostedtoolcache/flutter
-          key: ${{ runner.OS }}-flutter-install-cache
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: 'stable'
-      - name: Flutter pub get
-        run: flutter pub get
-      - name: Flutter format
-        run: dart format -o none --set-exit-if-changed .
-      - name: Flutter analyze
-        run: flutter analyze
+  call-global-iconica-workflow:
+    uses: Iconica-Development/.github/.github/workflows/component-ci.yml@master
+    secrets: inherit
+    permissions: write-all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+## [2.2.0] - 17 August 2023
+
+- Updated flutter_timetable to version 1.1.0
+- Updated flutter_date_time_picker to XXX
+
 ## [2.1.0] - 2 August 2023
 
 - Updated flutter_date_time_picker version to version 3.2.0
+
 ## [2.0.0] - 31 March 2023
 
 - Updated flutter_date_time_picker version to version 3.0.0

--- a/lib/flutter_roster.dart
+++ b/lib/flutter_roster.dart
@@ -12,4 +12,4 @@ export 'package:flutter_roster/src/models/roster_event.dart';
 export 'package:flutter_roster/src/models/roster_theme.dart';
 export 'package:flutter_roster/src/roster.dart';
 
-export 'package:timetable/timetable.dart';
+export 'package:flutter_timetable/timetable.dart';

--- a/lib/src/models/roster_theme.dart
+++ b/lib/src/models/roster_theme.dart
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import 'package:flutter_date_time_picker/flutter_date_time_picker.dart';
-import 'package:timetable/timetable.dart';
+import 'package:flutter_timetable/timetable.dart';
 
 class RosterTheme {
   /// [RosterTheme] is a class that contains all styling options

--- a/lib/src/roster.dart
+++ b/lib/src/roster.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_date_time_picker/flutter_date_time_picker.dart';
 import 'package:flutter_roster/src/models/roster_event.dart';
 import 'package:flutter_roster/src/models/roster_theme.dart';
-import 'package:timetable/timetable.dart';
+import 'package:flutter_timetable/timetable.dart';
 
 class RosterWidget extends StatefulWidget {
   /// [RosterWidget] is a widget that displays a timetable with events.
@@ -22,6 +22,7 @@ class RosterWidget extends StatefulWidget {
     this.alwaysUse24HourFormat,
     this.header,
     this.childIfEmptyRoster,
+    this.initialScrollTime,
     this.scrollController,
     this.scrollPhysics,
     this.onTapDay,
@@ -101,6 +102,9 @@ class RosterWidget extends StatefulWidget {
   /// The [Size] of the timetable.
   final Size? size;
 
+  /// The initial time to scroll to if there are no rosterevents. If nothing is provided it will scroll to the current time or to the first block if there is one.
+  final TimeOfDay? initialScrollTime;
+
   /// The scroll controller to control the scrolling of the timetable.
   final ScrollController? scrollController;
 
@@ -170,6 +174,7 @@ class _RosterWidgetState extends State<RosterWidget> {
                   )
                 : Timetable(
                     tableDirection: widget.tableDirection,
+                    initialScrollTime: widget.initialScrollTime,
                     scrollPhysics: widget.scrollPhysics,
                     scrollController: widget.scrollController,
                     blockColor: widget.blockColor,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_roster
 description: Roster widget with an underlying timetable included
-version: 2.1.0
+version: 2.2.0
 homepage: https://github.com/Iconica-Development/flutter_roster
 
 publish_to: none
@@ -16,10 +16,10 @@ dependencies:
     git:
       url: https://github.com/Iconica-Development/flutter_date_time_picker.git
       ref: 3.2.0
-  timetable:
+  flutter_timetable:
     git:
       url: https://github.com/Iconica-Development/flutter_timetable.git
-      ref: 1.0.0
+      ref: 1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Update the underlying flutter_timetable and cleanup the component a bit.
A new option for the timetable is added where the initialScrollTime can be set.