### PR TITLE
feat: add option to sort events by their id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.6.0] - 13 November 2023
+
+- Add the option for sorting the roster events by their id.
+
 ## [2.5.0] - 8 November 2023
 
 - Added the option for setting an offset for the hours so that the first hour is not 00:00 but 08:00 for example and the last hour can be after 24:00.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,6 +24,7 @@ class RosterDemo extends StatelessWidget {
       body: RosterWidget(
         enableBorderScroll: true,
         tableTopPadding: 130,
+        sortByIdAscending: true,
         tableDirection: Axis.horizontal,
         header: Padding(
             padding: EdgeInsets.symmetric(

--- a/lib/src/roster.dart
+++ b/lib/src/roster.dart
@@ -37,6 +37,7 @@ class RosterWidget extends StatefulWidget {
     this.blockDimension = 50,
     this.blockColor = const Color(0x80FF0000),
     this.theme = const RosterTheme(),
+    this.sortByIdAscending = false,
     this.enableBorderScroll = false,
     this.scrollTriggerOffset = 120,
     this.scrollJumpToOffset = 115,
@@ -93,6 +94,9 @@ class RosterWidget extends StatefulWidget {
   /// [bool] to set the clock on [TimePickerDialog] to a fixed 24 format.
   /// By default this gets determined by the settings on the user device.
   final bool? alwaysUse24HourFormat;
+
+  /// Whether or not to sort the events by their ID in ascending order.
+  final bool sortByIdAscending;
 
   /// The dimension in pixels of one hour in the timetable.
   final double hourDimension;
@@ -216,6 +220,7 @@ class _RosterWidgetState extends State<RosterWidget> {
                     theme: widget.theme.tableTheme,
                     combineBlocks: true,
                     mergeBlocks: false,
+                    sortByIdAscending: widget.sortByIdAscending,
                     scrollTriggerOffset: widget.scrollTriggerOffset,
                     scrollJumpToOffset: widget.scrollJumpToOffset,
                     onOverScroll: widget.enableBorderScroll

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_roster
 description: Roster widget with an underlying timetable included
-version: 2.5.0
+version: 2.6.0
 homepage: https://github.com/Iconica-Development/flutter_roster
 
 publish_to: none
@@ -19,7 +19,7 @@ dependencies:
   flutter_timetable:
     git:
       url: https://github.com/Iconica-Development/flutter_timetable
-      ref: 1.3.0
+      ref: 1.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
For Safino the events need to be sorted based on their ID so that is why the feature is added to the flutter_timetable and flutter_roster